### PR TITLE
Add ability to transform multiple selections at once.

### DIFF
--- a/lib/url-encode.coffee
+++ b/lib/url-encode.coffee
@@ -6,13 +6,14 @@ module.exports =
   encode: ->
     # This assumes the active pane item is an editor
     editor = atom.workspace.activePaneItem
-    selection = editor.getSelection()
+    selections = editor.getSelections()
+
     selection.insertText(encodeURIComponent(selection.getText()),
-      { "select": true})
+      { "select": true}) for selection in selections
 
   decode: ->
     # This assumes the active pane item is an editor
     editor = atom.workspace.activePaneItem
-    selection = editor.getSelection()
+    selections = editor.getSelections()
     selection.insertText(decodeURIComponent(selection.getText()),
-      { "select": true})
+      { "select": true}) for selection in selections


### PR DESCRIPTION
The Atom editor has ability  to select multiple lines and then execute action on this multiple selection. This is really useful with encoding functions as you can select only parts of the file that is url encoded and then decode all parts at once and other way around.

I use this feature in sublime quite frequently when working one outdated pice of software where things like this dictionary are popular:

```
{
   "key": "very%20long%20url%20encoded%20value",
   "another key": "and%20another%20value%20with%20quote%3A%20(%22)%20character"
}
```

Unfortunately the url-encode does not support this case yet, this pull request add this functionality. (fixes #1)
